### PR TITLE
fix: correção de entradas e saídas referente ao pc e nextPC

### DIFF
--- a/projetos/2/adder.v
+++ b/projetos/2/adder.v
@@ -1,8 +1,8 @@
-module Adder(nextPC, pc_increment);
+module Adder(pc, pc_increment);
 	// Declaração de entrada e saída
-	input [31:0] nextPC;
+	input [31:0] pc;
 	output [31:0] pc_increment;
-	// Declaração do 4 para somar ao nextPC
+	// Declaração do 4 para somar ao pc
 	reg [31:0] four;
 
 	// Inicialização do four com o número 4 em hexadecimal
@@ -10,7 +10,7 @@ module Adder(nextPC, pc_increment);
 		four = 32'h00000004;
 	end
 
-	// Atribuição da soma do PC
-	assign pc_increment = four + nextPC;
+	// Atribuição da soma do pc
+	assign pc_increment = four + pc;
 
 endmodule

--- a/projetos/2/counter.v
+++ b/projetos/2/counter.v
@@ -1,4 +1,4 @@
-module Counter(nextPC, pc_increment);
+module Adder(nextPC, pc_increment);
 	// Declaração de entrada e saída
 	input [31:0] nextPC;
 	output [31:0] pc_increment;

--- a/projetos/2/mips.v
+++ b/projetos/2/mips.v
@@ -1,4 +1,4 @@
-`include "counter.v"
+`include "adder.v"
 `include "i_mem.v"
 `include "mux.v"
 `include "pc.v"
@@ -9,9 +9,9 @@
 `include "utils.v"
 `include "d_mem.v"
 
-module mips(clock, reset, pc, ula_result, data_mem);
+module mips(clock, reset, nextPC, ula_result, data_mem);
 	input wire clock, reset;
-	output wire [31:0] pc, ula_result, data_mem;
+	output wire [31:0] nextPC, ula_result, data_mem;
 
 	wire [1:0] ula_operation;
 	// MÓDULO ULA_CONTROL
@@ -23,15 +23,15 @@ module mips(clock, reset, pc, ula_result, data_mem);
 	ula mips_ula(In1, In2, OP, ula_result, ula_zero_flag);
 	
 	// MÓDULO PC
-	wire [31:0] nextPC; // conterá o próximo endereço (a atualização da soma)
-	PC pc_check(pc, nextPC, clock);
+	//wire [31:0] nextPC; // conterá o próximo endereço (a atualização da soma)
+	PC pc_check(nextPC, pc, clock);
 
 	wire [31:0] pc_increment; // Representará o resultado da soma do valor do PC
-	Adder pc_counter(nextPC, pc_increment); // Módulo para atualizar o valor do PC
+	Adder pc_counter(pc, pc_increment); // Módulo para atualizar o valor do PC
 
 	// MÓDULO INSTRUÇÃO DE MEMÓRIA
 	wire [31:0] instruction;
-	i_mem current_instruction(nextPC, instruction);
+	i_mem current_instruction(pc, instruction);
 
 	// D_MEM MODULE
 	wire memWrite; //vem do controle
@@ -67,5 +67,5 @@ module mips(clock, reset, pc, ula_result, data_mem);
 	wire branch_sel; //Atribuição em caso de branching do PC para outra instrução
 	assign branch_sel = branch & ula_zero_flag; //AND de branching
 	// Atribuição da próxima instrução do Program Counter (PC)
-	mux_32 pc_mux(pc_increment, add_branching_to_mux, branch_sel, pc);
+	mux_32 pc_mux(pc_increment, add_branching_to_mux, branch_sel, nextPC);
 endmodule

--- a/projetos/2/mips.v
+++ b/projetos/2/mips.v
@@ -27,7 +27,7 @@ module mips(clock, reset, pc, ula_result, data_mem);
 	PC pc_check(pc, nextPC, clock);
 
 	wire [31:0] pc_increment; // Representará o resultado da soma do valor do PC
-	Counter pc_counter(nextPC, pc_increment); // Módulo para atualizar o valor do PC
+	Adder pc_counter(nextPC, pc_increment); // Módulo para atualizar o valor do PC
 
 	// MÓDULO INSTRUÇÃO DE MEMÓRIA
 	wire [31:0] instruction;

--- a/projetos/2/mips.v
+++ b/projetos/2/mips.v
@@ -41,7 +41,7 @@ module mips(clock, reset, nextPC, ula_result, data_mem);
 	ula mips_ula(ReadData1, In2, OP, ula_result, ula_zero_flag);
 	
 	// MÓDULO PC
-	//wire [31:0] nextPC; // conterá o próximo endereço (a atualização da soma)
+	wire [31:0] pc;
 	PC pc_check(nextPC, pc, clock);
 
 	wire [31:0] pc_increment; // Representará o resultado da soma do valor do PC
@@ -51,7 +51,7 @@ module mips(clock, reset, nextPC, ula_result, data_mem);
 	wire [31:0] instruction;
 	i_mem current_instruction(pc, instruction);
 
-	// D_MEM MODULE
+	// MÓDULO D_MEM
 	d_mem mips_d_mem(ula_result, ReadData2, data_mem, MemWrite, MemRead);
 
 	wire WriteData;
@@ -67,7 +67,7 @@ module mips(clock, reset, nextPC, ula_result, data_mem);
 	// MUX (regfile e ula)
 	mux_src mips_mux_src(ALUSrc, ReadData2, sign_extend_to_mux, In2);
 
-	//Sign extend from 16 to 32 bits
+	//Sign extend de 16 para 32 bits
 	wire [31:0] sign_extend_to_mux;
 	sign_extend mips_sign_extend(instruction[15:0], sign_extend_to_mux);
 

--- a/projetos/2/pc.v
+++ b/projetos/2/pc.v
@@ -1,25 +1,25 @@
-module PC(PC, nextPC, clock);
+module PC(nextPC, pc, clock);
 	// Declaração de entradas e saída
-	input wire [31:0] PC;
-	output reg [31:0] nextPC;
 	input clock;
+	input wire [31:0] nextPC;
+	output reg [31:0] pc;
 	// Declaração de flag
 	reg reset;
 
-	// Inicializando reset e nextPC com 0
+	// Inicializando reset e pc com 0
 	initial begin
 		reset = 0;
-		nextPC = 32'b0;
+		pc = 32'b0;
 	end
 
-	// Atribuição síncrona. Se reset == 1, nextPC recebe o mesmo
-	// valor que PC, caso contrário nextPC é setado em 0 e reset ´
+	// Atribuição síncrona. Se reset == 1, pc recebe o mesmo
+	// valor que nextPC, caso contrário pc é setado em 0 e reset ´
 	// tem o valor alterado
 	always @(posedge clock) begin
 		if(reset) begin
-			nextPC = PC;
+			pc = nextPC;
 		end else begin
-			nextPC = 32'b0;
+			pc = 32'b0;
 			reset = 1;
 		end
 	end


### PR DESCRIPTION
**1. What this MR does / why we need it:**
Essa PR corrige o erro referente à declaração de portas do módulo `PC` que foi especificada no documento do projeto. Antes, o `pc` estava declarado como input e o `nextPC` como output, porém é o contrário e agora está devidamente corrigido. 

![Captura de tela 2023-04-06 121613](https://user-images.githubusercontent.com/66442236/230423423-3ebb5dd3-0e5a-4ca0-8865-92c49b833e08.png)

Antes, o módulo PC se encontrava assim:

![Captura de tela 2023-04-06 103112](https://user-images.githubusercontent.com/66442236/230424693-4d1bb777-4be9-4497-afd8-76bef0c5756f.png)

Agora está assim com a correção:

![Captura de tela 2023-04-06 105646](https://user-images.githubusercontent.com/66442236/230424640-59679433-8de8-4753-8302-9d60545eeffb.png)

**2. Special notes for your reviewer**
Ao fazer a correção houve impacto na implementação dos seguintes módulos: `Adder` e `mux_32`. Contudo, ao analisar e modificar adequadamente as entradas e saídas, os módulos voltaram à operar devidamente como antes e o RTL permaneceu.

![Captura de tela 2023-04-06 115132](https://user-images.githubusercontent.com/66442236/230424863-c6b490a1-ec34-475e-840e-70bc89f55958.png)
