### PR TITLE
Implementação das instruções srl, sll e sra

### DIFF
--- a/projetos/2/mips.v
+++ b/projetos/2/mips.v
@@ -38,7 +38,7 @@ module mips(clock, reset, nextPC, ula_result, data_mem);
 	wire [31:0] In2;
 	wire [3:0] OP;
 	wire ula_zero_flag;
-	ula mips_ula(ReadData1, In2, OP, ula_result, ula_zero_flag);
+	ula mips_ula(ReadData1, In2, OP, instruction[10:6], ula_result, ula_zero_flag);
 	
 	// MÓDULO PC
 	wire [31:0] pc;

--- a/projetos/2/mips.v
+++ b/projetos/2/mips.v
@@ -54,7 +54,7 @@ module mips(clock, reset, nextPC, ula_result, data_mem);
 	// MÓDULO D_MEM
 	d_mem mips_d_mem(ula_result, ReadData2, data_mem, MemWrite, MemRead);
 
-	wire WriteData;
+	wire [31:0] WriteData;
 	mux_32 mux_32_d_mem(data_mem, ula_result, MemtoReg, WriteData);
 
 	// MUX (i_mem e regfile)
@@ -66,7 +66,7 @@ module mips(clock, reset, nextPC, ula_result, data_mem);
 	regfile mips_regfile(instruction[25:21], instruction[20:16], ReadData1, ReadData2, clock, imem_mux_to_write_register, WriteData, RegWrite, reset);
 
 	// MUX (regfile e ula)
-	mux_32 regfile_mux(ReadData2, sign_extend_to_mux, ALUsrc, regfile_mux_to_ula_In2);
+	mux_32 regfile_mux(ReadData2, sign_extend_to_mux, ALUSrc, regfile_mux_to_ula_In2);
 
 	//Sign extend de 16 para 32 bits
 	wire [31:0] sign_extend_to_mux;

--- a/projetos/2/mips.v
+++ b/projetos/2/mips.v
@@ -35,10 +35,10 @@ module mips(clock, reset, nextPC, ula_result, data_mem);
 	// MÓDULO ULA_CONTROL
 	ula_control mips_ula_control(ula_operation, instruction[5:0], OP);
 	// MÓDULO ULA
-	wire [31:0] In2;
+	wire [31:0] regfile_mux_to_ula_In2;
 	wire [3:0] OP;
 	wire ula_zero_flag;
-	ula mips_ula(ReadData1, In2, OP, instruction[10:6], ula_result, ula_zero_flag);
+	ula mips_ula(ReadData1, regfile_mux_to_ula_In2, OP, instruction[10:6], ula_result, ula_zero_flag);
 	
 	// MÓDULO PC
 	wire [31:0] pc;

--- a/projetos/2/mips.v
+++ b/projetos/2/mips.v
@@ -58,6 +58,7 @@ module mips(clock, reset, nextPC, ula_result, data_mem);
 	mux_32 mux_32_d_mem(data_mem, ula_result, MemtoReg, WriteData);
 
 	// MUX (i_mem e regfile)
+	wire [4:0] imem_mux_to_write_register;
 	mux_5 imem_reg_mux(instruction[20:16], instruction[15:11], RegDst, imem_mux_to_write_register);
 
 	// MÓDULO REGFILE

--- a/projetos/2/mips.v
+++ b/projetos/2/mips.v
@@ -58,14 +58,14 @@ module mips(clock, reset, nextPC, ula_result, data_mem);
 	mux_32 mux_32_d_mem(data_mem, ula_result, MemtoReg, WriteData);
 
 	// MUX (i_mem e regfile)
-	mux_4 imem_reg_mux(instruction[20:16], instruction[15:11], RegDst, imem_mux_to_write_register);
+	mux_5 imem_reg_mux(instruction[20:16], instruction[15:11], RegDst, imem_mux_to_write_register);
 
 	// MÓDULO REGFILE
 	wire [31:0] ReadData1, ReadData2;
 	regfile mips_regfile(instruction[25:21], instruction[20:16], ReadData1, ReadData2, clock, imem_mux_to_write_register, WriteData, RegWrite, reset);
 
 	// MUX (regfile e ula)
-	mux_src mips_mux_src(ALUSrc, ReadData2, sign_extend_to_mux, In2);
+	mux_src mips_mux_src(ALUSrc, ReadData2, sign_extend_to_mux, regfile_mux_to_ula_In2);
 
 	//Sign extend de 16 para 32 bits
 	wire [31:0] sign_extend_to_mux;

--- a/projetos/2/mux.v
+++ b/projetos/2/mux.v
@@ -26,7 +26,7 @@ module mux_src(ALUsrc, ReadData2, SignExtended32, ALUin2);
 	end
 endmodule
 
-module mux_4(inst0, inst1, RegDst, imem_mux_to_write_register);
+module mux_5(inst0, inst1, RegDst, imem_mux_to_write_register);
 	// Declaração das entradas e saída
 	input [4:0] inst0, inst1;
 	input RegDst; // <= vem da Control

--- a/projetos/2/ula.v
+++ b/projetos/2/ula.v
@@ -14,13 +14,15 @@ module ula(In1, In2, OP, shamt, result, Zero_flag);
 			4'b0000: ula_result <= In1 & In2; //0000: AND
 			4'b0001: ula_result <= In1 | In2; //0001: OR
 			4'b0010: ula_result <= In1 + In2; //0010: ADD
+			4'b0011: ula_result <= In2 << shamt; //0011: Shift left (SLL)
+			4'b0101: ula_result <= In2 >> shamt; //0101: Shift right (SRL e SRA)
 			4'b0110: ula_result <= In1 - In2; //0110: SUB
 			4'b0111: ula_result <= (In1 < In2) ? 32'd1 : 32'd0; //0111: SLT
 			4'b1011: ula_result <= {In2[15:0], 16'h0000}; //1011: LUI
 			4'b1100: ula_result <= ~ (In1 | In2); //1100: NOR
 			4'b1101: ula_result <= In1 ^ In2; //1101: XOR
-			4'b1110: ula_result <= In2 << shamt; //1110: Shift left
-			4'b1111: ula_result <= In2 >> shamt; //1111: Shift right
+			4'b1110: ula_result <= In2 << In1; //1110: SLLV
+			4'b1111: ula_result <= In2 >> In1; //1111: SRLV e SRAV
 			default: ula_result <= In1 + In2; //defaults to AND
 		endcase
 	end

--- a/projetos/2/ula.v
+++ b/projetos/2/ula.v
@@ -1,6 +1,7 @@
-module ula(In1, In2, OP, result, Zero_flag);
+module ula(In1, In2, OP, shamt, result, Zero_flag);
 	input wire [31:0] In1, In2;
 	input wire [3:0] OP;
+	input wire [4:0] shamt;
 	output wire [31:0] result;
 	output wire Zero_flag;
 
@@ -18,8 +19,8 @@ module ula(In1, In2, OP, result, Zero_flag);
 			4'b1011: ula_result <= {In2[15:0], 16'h0000}; //1011: LUI
 			4'b1100: ula_result <= ~ (In1 | In2); //1100: NOR
 			4'b1101: ula_result <= In1 ^ In2; //1101: XOR
-			4'b1110: ula_result <= In2 << In1; //1110: Shift left
-			4'b1111: ula_result <= In2 >> In1; //1111: Shift right
+			4'b1110: ula_result <= In2 << shamt; //1110: Shift left
+			4'b1111: ula_result <= In2 >> shamt; //1111: Shift right
 			default: ula_result <= In1 + In2; //defaults to AND
 		endcase
 	end

--- a/projetos/2/ula_control.v
+++ b/projetos/2/ula_control.v
@@ -12,6 +12,9 @@ module ula_control(ula_operation, func, operation);
                     6'b000100: operation <= 4'b1110; //SLLV
                     6'b000110: operation <= 4'b1111; //SRLV
                     6'b000111: operation <= 4'b1111; //SRAV
+                    6'b000011: operation <= 4'b0101; //SRA
+                    6'b000010: operation <= 4'b0101; //SRL
+                    6'b000000: operation <= 4'b0011; //SLL
                     6'b100000: operation <= 4'b0010; //add
                     6'b100010: operation <= 4'b0110; //sub
                     6'b100100: operation <= 4'b0000; //and


### PR DESCRIPTION
**1. What this MR does / why we need it:**

Essa PR busca implementar as funções restantes de `sll`, `sra` e `srl` sem o imediato. Logo, houve a adição de uma nova porta ao arquivo `ula.v` referente aos bits de representação do `shamt` da instrução. 

**2. Special notes**
Coloquei o func em binário das instruções acima no arquivo `ula_control.v` e os referenciei no `ula.v`. Como existem essas instruções para imediatos também, fiz a "duplicação" do código para contemplar as especificações (com e sem `shamt`) das outras instruções.